### PR TITLE
Fix mapping of "BP_OCI_SOURCE" variable

### DIFF
--- a/labels/labels.go
+++ b/labels/labels.go
@@ -24,7 +24,7 @@ var Labels = map[string]string{
 	"BP_OCI_LICENSES":      "org.opencontainers.image.licenses",
 	"BP_OCI_REF_NAME":      "org.opencontainers.image.ref.name",
 	"BP_OCI_REVISION":      "org.opencontainers.image.revision",
-	"BP_OCI_SOURCE":        "org.opencontainers.image.revision",
+	"BP_OCI_SOURCE":        "org.opencontainers.image.source",
 	"BP_OCI_TITLE":         "org.opencontainers.image.title",
 	"BP_OCI_URL":           "org.opencontainers.image.url",
 	"BP_OCI_VENDOR":        "org.opencontainers.image.vendor",


### PR DESCRIPTION
I was attempting to build an image using Spring Boot's new docker image building feature, and noticed that my source URL wasn't being set. 