### PR TITLE
Reformat buildpack.toml

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -15,99 +15,91 @@
 api = "0.6"
 
 [buildpack]
-id       = "paketo-buildpacks/image-labels"
-name     = "Paketo Image Labels Buildpack"
-version  = "{{.version}}"
-homepage = "https://github.com/paketo-buildpacks/image-labels"
-description = "A Cloud Native Buildpack that enables configuration of labels on the created image"
-keywords    = ["image-labels", "labels"]
+  description = "A Cloud Native Buildpack that enables configuration of labels on the created image"
+  homepage = "https://github.com/paketo-buildpacks/image-labels"
+  id = "paketo-buildpacks/image-labels"
+  keywords = ["image-labels", "labels"]
+  name = "Paketo Image Labels Buildpack"
+  version = "{{.version}}"
 
-[[buildpack.licenses]]
-type = "Apache-2.0"
-uri  = "https://github.com/paketo-buildpacks/image-labels/blob/main/LICENSE"
-
-[[stacks]]
-id = "io.buildpacks.stacks.bionic"
-
-[[stacks]]
-id = "io.paketo.stacks.tiny"
-
-[[stacks]]
-id = "*"
-
-[[metadata.configurations]]
-name        = "BP_IMAGE_LABELS"
-description = "arbitrary image labels"
-build       = true
-
-[[metadata.configurations]]
-name        = "BP_OCI_AUTHORS"
-description = "the org.opencontainers.image.authors image label"
-build       = true
-
-[[metadata.configurations]]
-name        = "BP_OCI_CREATED"
-description = "the org.opencontainers.image.created image label"
-build       = true
-
-[[metadata.configurations]]
-name        = "BP_OCI_DESCRIPTION"
-description = "the org.opencontainers.image.description image label"
-build       = true
-
-[[metadata.configurations]]
-name        = "BP_OCI_DOCUMENTATION"
-description = "the org.opencontainers.image.documentation image label"
-build       = true
-
-[[metadata.configurations]]
-name        = "BP_OCI_LICENSES"
-description = "the org.opencontainers.image.licenses image label"
-build       = true
-
-[[metadata.configurations]]
-name        = "BP_OCI_REF_NAME"
-description = "the org.opencontainers.image.ref.name image label"
-build       = true
-
-[[metadata.configurations]]
-name        = "BP_OCI_REVISION"
-description = "the org.opencontainers.image.revision image label"
-build       = true
-
-[[metadata.configurations]]
-name        = "BP_OCI_SOURCE"
-description = "the org.opencontainers.image.revision image label"
-build       = true
-
-[[metadata.configurations]]
-name        = "BP_OCI_TITLE"
-description = "the org.opencontainers.image.title image label"
-build       = true
-
-[[metadata.configurations]]
-name        = "BP_OCI_URL"
-description = "the org.opencontainers.image.url image label"
-build       = true
-
-[[metadata.configurations]]
-name        = "BP_OCI_VENDOR"
-description = "the org.opencontainers.image.vendor image label"
-build       = true
-
-[[metadata.configurations]]
-name        = "BP_OCI_VERSION"
-description = "the org.opencontainers.image.version image label"
-build       = true
+  [[buildpack.licenses]]
+    type = "Apache-2.0"
+    uri = "https://github.com/paketo-buildpacks/image-labels/blob/main/LICENSE"
 
 [metadata]
-pre-package   = "scripts/build.sh"
-include-files = [
-  "LICENSE",
-  "NOTICE",
-  "README.md",
-  "bin/build",
-  "bin/detect",
-  "bin/main",
-  "buildpack.toml",
-]
+  include-files = ["LICENSE", "NOTICE", "README.md", "bin/build", "bin/detect", "bin/main", "buildpack.toml"]
+  pre-package = "scripts/build.sh"
+
+  [[metadata.configurations]]
+    build = true
+    description = "arbitrary image labels"
+    name = "BP_IMAGE_LABELS"
+
+  [[metadata.configurations]]
+    build = true
+    description = "the org.opencontainers.image.authors image label"
+    name = "BP_OCI_AUTHORS"
+
+  [[metadata.configurations]]
+    build = true
+    description = "the org.opencontainers.image.created image label"
+    name = "BP_OCI_CREATED"
+
+  [[metadata.configurations]]
+    build = true
+    description = "the org.opencontainers.image.description image label"
+    name = "BP_OCI_DESCRIPTION"
+
+  [[metadata.configurations]]
+    build = true
+    description = "the org.opencontainers.image.documentation image label"
+    name = "BP_OCI_DOCUMENTATION"
+
+  [[metadata.configurations]]
+    build = true
+    description = "the org.opencontainers.image.licenses image label"
+    name = "BP_OCI_LICENSES"
+
+  [[metadata.configurations]]
+    build = true
+    description = "the org.opencontainers.image.ref.name image label"
+    name = "BP_OCI_REF_NAME"
+
+  [[metadata.configurations]]
+    build = true
+    description = "the org.opencontainers.image.revision image label"
+    name = "BP_OCI_REVISION"
+
+  [[metadata.configurations]]
+    build = true
+    description = "the org.opencontainers.image.revision image label"
+    name = "BP_OCI_SOURCE"
+
+  [[metadata.configurations]]
+    build = true
+    description = "the org.opencontainers.image.title image label"
+    name = "BP_OCI_TITLE"
+
+  [[metadata.configurations]]
+    build = true
+    description = "the org.opencontainers.image.url image label"
+    name = "BP_OCI_URL"
+
+  [[metadata.configurations]]
+    build = true
+    description = "the org.opencontainers.image.vendor image label"
+    name = "BP_OCI_VENDOR"
+
+  [[metadata.configurations]]
+    build = true
+    description = "the org.opencontainers.image.version image label"
+    name = "BP_OCI_VERSION"
+
+[[stacks]]
+  id = "io.buildpacks.stacks.bionic"
+
+[[stacks]]
+  id = "io.paketo.stacks.tiny"
+
+[[stacks]]
+  id = "*"


### PR DESCRIPTION
## Summary
The pipeline-builder tools have changed and the buildpack.toml has been rearranged slightly (keys are now alphabetized). This PR keeps the format inline with the other buildpacks.


## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
