### PR TITLE
Implement RFC 0050: Rename Buildpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # `gcr.io/paketo-buildpacks/image-labels`
-The Paketo Image Labels Buildpack is a Cloud Native Buildpack that enables configuration of labels on the created image.
+The Paketo Buildpack for Image Labels is a Cloud Native Buildpack that enables configuration of labels on the created image.
 
 This buildpack allows for the configuration of both [OCI-specified][o] labels with short environment variable names, as well as arbitrary labels using a space-delimited syntax in a single environment variable.
 

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -19,7 +19,7 @@ api = "0.7"
   homepage = "https://github.com/paketo-buildpacks/image-labels"
   id = "paketo-buildpacks/image-labels"
   keywords = ["image-labels", "labels"]
-  name = "Paketo Image Labels Buildpack"
+  name = "Paketo Buildpack for Image Labels"
   version = "{{.version}}"
   sbom-formats = ["application/vnd.cyclonedx+json", "application/vnd.syft+json"]
 


### PR DESCRIPTION
Renames 'Paketo Image Labels Buildpack' to 'Paketo Buildpack for Image Labels'.

Implements RFC 0050, https://github.com/paketo-buildpacks/rfcs/issues/233, for this buildpack.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>
