### PR TITLE
Update buildpack.toml

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -73,7 +73,7 @@ api = "0.7"
 
   [[metadata.configurations]]
     build = true
-    description = "the org.opencontainers.image.revision image label"
+    description = "the org.opencontainers.image.source image label"
     name = "BP_OCI_SOURCE"
 
   [[metadata.configurations]]


### PR DESCRIPTION
Fix label description for BP_OCI_SOURCE

## Summary
The description for variable `BC_OCI_SOURCE` doesn't match the corresponding label. It is fixed by using correct image label `org.opencontainers.image.source`. Label `org.opencontainers.image.revision` was erroneously used in the description.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
