### PR TITLE
Add detection logging messages at info level

### DIFF
--- a/labels/detect.go
+++ b/labels/detect.go
@@ -18,6 +18,8 @@ package labels
 
 import (
 	"fmt"
+	"github.com/paketo-buildpacks/libpak/bard"
+	"os"
 
 	"github.com/buildpacks/libcnb"
 	"github.com/paketo-buildpacks/libpak"
@@ -26,7 +28,8 @@ import (
 type Detect struct{}
 
 func (Detect) Detect(context libcnb.DetectContext) (libcnb.DetectResult, error) {
-	cr, err := libpak.NewConfigurationResolver(context.Buildpack, nil)
+	l := bard.NewLogger(os.Stdout)
+	cr, err := libpak.NewConfigurationResolver(context.Buildpack, &l)
 	if err != nil {
 		return libcnb.DetectResult{}, fmt.Errorf("unable to create configuration resolver\n%w", err)
 	}
@@ -42,6 +45,7 @@ func (Detect) Detect(context libcnb.DetectContext) (libcnb.DetectResult, error) 
 	pass = pass || ok
 
 	if !pass {
+		l.Logger.Info("SKIPPED: No supported environment variables were set")
 		return libcnb.DetectResult{Pass: false}, nil
 	}
 


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

*Log messages were checked during testing*
```
=== RUN   TestUnit/labels/Detect/fails_without_any_interesting_environment_variables_set
SKIPPED: No supported environment variables were set
```

## Summary
This PR adds additional logging when Detect returns false for this buildpack. This is to provide more information about why the detection failed for this buildpack when verbose/debug logging is enabled. 

As of lifecycle v1.16.0, if the detect phase fails as a whole, log messages are printed at info level by default, without the need for the verbose flag.

## Use Cases
A `pack build` command with the `--verbose` flag set will show these log statement if detection fails. If Detect succeeds, the output is not shown unless `--verbose` is set.

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).